### PR TITLE
Support including fff via Meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project('fff', 'c',
+  license: 'MIT',
+  version: '4.0',
+)
+
+fff_includes = include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('fff', 'c',
   license: 'MIT',
-  version: '4.0',
+  version: '0.0.0',
 )
 
 fff_includes = include_directories('.')


### PR DESCRIPTION
No Meson file was included to provide the include dir for fff when including fff as a subproject.

A Meson file has been added that provides the include dir containing fff.

- resolves #1 

Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are not breaking consistency
- [ ] You have added unit tests
- [x] All tests and other checks pass
